### PR TITLE
Add missing keywords to highlighting list

### DIFF
--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -71,7 +71,7 @@ hi def link     vFlag               Include
 hi def link     vShebang            Include
 
 " Keywords within functions
-syn keyword     vStatement          defer go goto return break continue
+syn keyword     vStatement          defer go goto return break continue lock rlock shared
 hi def link     vStatement          Statement
 
 syn keyword     vConditional        if else match or select

--- a/syntax/vlang.vim
+++ b/syntax/vlang.vim
@@ -71,7 +71,7 @@ hi def link     vFlag               Include
 hi def link     vShebang            Include
 
 " Keywords within functions
-syn keyword     vStatement          defer go goto return break continue lock rlock shared
+syn keyword     vStatement          defer go goto return break continue lock rlock shared none
 hi def link     vStatement          Statement
 
 syn keyword     vConditional        if else match or select


### PR DESCRIPTION
`rlock`, `lock`, `shared`, and `none` are all highlighted in html  block, therefore these keywords should also be highlighted in vim.